### PR TITLE
Compatibility with requests-2.11

### DIFF
--- a/hubic_remote/swift.py
+++ b/hubic_remote/swift.py
@@ -203,7 +203,7 @@ class SwiftConnection(object):
 
                     # Chunk metadata
                     headers = {
-                        "x-object-meta-annex-chunks": len(chunks),
+                        "x-object-meta-annex-chunks": str(len(chunks)),
                         "x-object-meta-annex-global-md5": md5_digest,
                     }
                     if idx < len(chunks) - 1:


### PR DESCRIPTION
Before this change, lots of operations used to fail with errors such as

  Header value 1 must be of type str or bytes, not <class 'int'>

when using newer versions of requests.
